### PR TITLE
Polish quest and emitter UI, unify system bars

### DIFF
--- a/app/src/main/java/com/example/indytrail/MainActivity.kt
+++ b/app/src/main/java/com/example/indytrail/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import com.example.indytrail.core.ScanRoute
 import com.example.indytrail.core.parseScanUri
+import com.example.indytrail.ui.ImmersiveSystemBars
 import com.example.indytrail.ui.theme.IndyTrailTheme
 
 class MainActivity : ComponentActivity() {
@@ -27,6 +28,7 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             IndyTrailTheme {
+                ImmersiveSystemBars()
 
                 // -------- Quest‑Store --------
                 val questStore = remember { com.example.indytrail.data.QuestStore() }

--- a/app/src/main/java/com/example/indytrail/ui/LumenEmitterScreen.kt
+++ b/app/src/main/java/com/example/indytrail/ui/LumenEmitterScreen.kt
@@ -135,125 +135,131 @@ fun LumenEmitterScreen(
                 modifier = Modifier.size(1.dp)
             )
 
-            // --- Fortschritts‑LEDs ---
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                repeat(expected.size) { i ->
-                    val on = i < idx
-                    Box(
-                        Modifier
-                            .size(12.dp)
-                            .clip(CircleShape)
-                            .background(if (on) cyan else cyan.copy(alpha = 0.2f))
-                    )
-                }
-            }
-
-            Spacer(Modifier.height(12.dp))
-
-            // --- Optional: Torch‑Buttons ---
-            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                Button(
-                    enabled = camera != null,
-                    onClick = { camera?.cameraControl?.enableTorch(true) }
-                ) { Text("Torch ON") }
-
-                OutlinedButton(
-                    enabled = camera != null,
-                    onClick = { camera?.cameraControl?.enableTorch(false) }
-                ) { Text("Torch OFF") }
-            }
-
-            Spacer(Modifier.height(12.dp))
-
-            // --- Runen‑Zeile aus expected (sichtbare Hinweise) ---
-            if (expectedSymbols.isNotEmpty()) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    expectedSymbols.forEach { sym ->
-                        Surface(
-                            shape = RoundedCornerShape(10.dp),
-                            tonalElevation = 2.dp,
-                            border = BorderStroke(1.dp, cyan.copy(alpha = 0.35f)),
-                            color = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f)
-                        ) {
-                            Box(
-                                Modifier
-                                    .size(44.dp),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Text(
-                                    text = sym,
-                                    // Falls du eine eigene Glyph‑Schrift nutzt:
-                                    // fontFamily = IndyGlyphs,
-                                    style = MaterialTheme.typography.titleLarge.copy(
-                                        letterSpacing = 2.sp
-                                    ),
-                                    color = cyan
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-
-            // --- (Optional) zusätzlich die vom Quest gelieferten Codes als Chips ---
-            if (hintGlyphs.isNotEmpty()) {
-                Spacer(Modifier.height(8.dp))
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    hintGlyphs.forEach { code ->
-                        AssistChip(onClick = {}, label = { Text(code ?: "?") })
-                    }
-                }
-            }
-
             Spacer(Modifier.height(16.dp))
 
-            // --- 3x3‑Tastenfeld (1..9) ---
-            val keys = (1..9).map(Int::toString)
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                for (r in 0 until 3) {
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                tonalElevation = 4.dp,
+                border = BorderStroke(1.dp, cyan.copy(alpha = 0.35f)),
+                color = MaterialTheme.colorScheme.surface.copy(alpha = 0.96f)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    // --- Fortschritts‑LEDs ---
                     Row(
-                        Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        verticalAlignment = Alignment.CenterVertically
                     ) {
-                        for (c in 1..3) {
-                            val label = keys[r * 3 + (c - 1)]
-                            Button(
-                                onClick = { press(label) },
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .height(56.dp),
-                                shape = RoundedCornerShape(12.dp)
+                        repeat(expected.size) { i ->
+                            val on = i < idx
+                            Box(
+                                Modifier
+                                    .size(12.dp)
+                                    .clip(CircleShape)
+                                    .background(if (on) cyan else cyan.copy(alpha = 0.2f))
+                            )
+                        }
+                    }
+
+                    Spacer(Modifier.height(12.dp))
+
+                    // --- Optional: Torch‑Buttons ---
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        Button(
+                            enabled = camera != null,
+                            onClick = { camera?.cameraControl?.enableTorch(true) }
+                        ) { Text("Torch ON") }
+
+                        OutlinedButton(
+                            enabled = camera != null,
+                            onClick = { camera?.cameraControl?.enableTorch(false) }
+                        ) { Text("Torch OFF") }
+                    }
+
+                    Spacer(Modifier.height(12.dp))
+
+                    // --- Runen‑Zeile aus expected (sichtbare Hinweise) ---
+                    if (expectedSymbols.isNotEmpty()) {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            expectedSymbols.forEach { sym ->
+                                Surface(
+                                    shape = RoundedCornerShape(10.dp),
+                                    tonalElevation = 2.dp,
+                                    border = BorderStroke(1.dp, cyan.copy(alpha = 0.35f)),
+                                    color = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f)
+                                ) {
+                                    Box(
+                                        Modifier
+                                            .size(44.dp),
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        Text(
+                                            text = sym,
+                                            style = MaterialTheme.typography.titleLarge.copy(
+                                                letterSpacing = 2.sp
+                                            ),
+                                            color = cyan
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // --- (Optional) zusätzlich die vom Quest gelieferten Codes als Chips ---
+                    if (hintGlyphs.isNotEmpty()) {
+                        Spacer(Modifier.height(8.dp))
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            hintGlyphs.forEach { code ->
+                                AssistChip(onClick = {}, label = { Text(code ?: "?") })
+                            }
+                        }
+                    }
+
+                    Spacer(Modifier.height(16.dp))
+
+                    // --- 3x3‑Tastenfeld (1..9) ---
+                    val keys = (1..9).map(Int::toString)
+                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        for (r in 0 until 3) {
+                            Row(
+                                Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(12.dp)
                             ) {
-                                Text(
-                                    label,
-                                    style = MaterialTheme.typography.titleMedium.copy(
-                                        fontWeight = FontWeight.SemiBold,
-                                        letterSpacing = 1.2.sp
-                                    )
-                                )
+                                for (c in 1..3) {
+                                    val label = keys[r * 3 + (c - 1)]
+                                    Button(
+                                        onClick = { press(label) },
+                                        modifier = Modifier
+                                            .weight(1f)
+                                            .height(56.dp),
+                                        shape = RoundedCornerShape(12.dp)
+                                    ) {
+                                        Text(
+                                            label,
+                                            style = MaterialTheme.typography.titleMedium.copy(
+                                                fontWeight = FontWeight.SemiBold,
+                                                letterSpacing = 1.2.sp
+                                            )
+                                        )
+                                    }
+                                }
                             }
                         }
                     }
                 }
             }
-
-            Spacer(Modifier.height(12.dp))
-
-            // Debug‑Anzeige
-            Text(
-                "Expected: " + expected.joinToString("-"),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
         }
     }
 }

--- a/app/src/main/java/com/example/indytrail/ui/QuestScreen.kt
+++ b/app/src/main/java/com/example/indytrail/ui/QuestScreen.kt
@@ -8,10 +8,15 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.text.font.FontWeight
@@ -20,6 +25,7 @@ import androidx.compose.ui.unit.sp
 import com.example.indytrail.data.QuestStore
 import com.example.indytrail.data.GlyphCatalog     // <- Mapping "PSI" -> sichtbares Zeichen
 import com.example.indytrail.ui.theme.IndyGlyphs  // <- deine eingebettete Glyph-Schrift (optional)
+import kotlinx.coroutines.delay
 
 @Composable
 fun QuestScreen(
@@ -40,6 +46,17 @@ fun QuestScreen(
     val progress = store.snapshot(questId)
     val slots = (1..4).map { i -> progress[i] } // List<String?>
     val foundCount = slots.count { !it.isNullOrBlank() }
+    val questComplete = foundCount == 4
+    var showComplete by remember { mutableStateOf(false) }
+
+    LaunchedEffect(questComplete) {
+        if (questComplete) {
+            delay(800)
+            showComplete = true
+        } else {
+            showComplete = false
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -134,13 +151,14 @@ fun QuestScreen(
 
             Spacer(Modifier.height(12.dp))
 
-// --- TEMP: immer sichtbarer Debug-Button, um Emitter zu öffnen ---
             OutlinedButton(
                 onClick = onOpenEmitter,
+                enabled = foundCount == 4,
+                modifier = Modifier.alpha(if (foundCount == 4) 1f else 0.5f),
                 shape = RoundedCornerShape(14.dp)
             ) {
                 Text(
-                    "Open Lumen Emitter (debug)",
+                    "Open Lumen Emitter",
                     style = MaterialTheme.typography.titleMedium.copy(letterSpacing = 1.2.sp)
                 )
             }
@@ -154,6 +172,41 @@ fun QuestScreen(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+
+            AnimatedVisibility(
+                visible = showComplete,
+                enter = fadeIn() + slideInVertically(),
+                exit = fadeOut()
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 24.dp)
+                ) {
+                    Text(
+                        text = "QUEST COMPLETE",
+                        style = MaterialTheme.typography.headlineMedium.copy(
+                            fontWeight = FontWeight.Bold,
+                            letterSpacing = 2.sp
+                        ),
+                        color = cyan
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    Button(
+                        onClick = onBack,
+                        shape = RoundedCornerShape(14.dp)
+                    ) {
+                        Text(
+                            "Finish Quest",
+                            style = MaterialTheme.typography.titleMedium.copy(
+                                fontWeight = FontWeight.SemiBold,
+                                letterSpacing = 1.5.sp
+                            )
+                        )
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/indytrail/ui/ScanScreen.kt
+++ b/app/src/main/java/com/example/indytrail/ui/ScanScreen.kt
@@ -1,7 +1,6 @@
 package com.example.indytrail.ui
 
 import android.Manifest
-import android.app.Activity
 import android.content.pm.PackageManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -32,9 +31,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
-import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
 import com.google.mlkit.vision.barcode.BarcodeScanning
 import com.google.mlkit.vision.common.InputImage
 
@@ -47,26 +43,6 @@ fun ScanScreen(
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
-
-    // —— Immerse: Status- & Navigationsleiste im Scanner ausblenden
-    LaunchedEffect(Unit) {
-        val activity = context as Activity
-        WindowCompat.setDecorFitsSystemWindows(activity.window, false)
-        WindowInsetsControllerCompat(activity.window, activity.window.decorView).apply {
-            hide(WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.navigationBars())
-            systemBarsBehavior =
-                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-        }
-    }
-    DisposableEffect(Unit) {
-        onDispose {
-            // beim Verlassen wieder normales Verhalten
-            val activity = context as Activity
-            WindowCompat.setDecorFitsSystemWindows(activity.window, true)
-            WindowInsetsControllerCompat(activity.window, activity.window.decorView)
-                .show(WindowInsetsCompat.Type.systemBars())
-        }
-    }
 
     // —— Kamera-Rechte
     var hasPermission by remember {


### PR DESCRIPTION
## Summary
- Extend Lumen emitter pad background and remove debug sequence text
- Delay and animate quest completion message with a disabled emitter button
- Apply immersive system bars globally and simplify scan screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c9fec34d8832db47525bd9eaa1087