### PR TITLE
Polish UI and improve immersive experience

### DIFF
--- a/app/src/main/java/com/example/indytrail/ui/LumenEmitterScreen.kt
+++ b/app/src/main/java/com/example/indytrail/ui/LumenEmitterScreen.kt
@@ -49,6 +49,8 @@ fun LumenEmitterScreen(
     onBack: () -> Unit,
     onSuccess: () -> Unit
 ) {
+    ImmersiveSystemBars()
+
     val cyan = MaterialTheme.colorScheme.primary
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -211,13 +213,18 @@ fun LumenEmitterScreen(
                 EmitterOverlay(codeVisible)
             }
 
-            Column(
+            Surface(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .weight(1f)
-                    .padding(16.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
+                    .weight(1f),
+                color = MaterialTheme.colorScheme.surface
             ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(10.dp),
                     verticalAlignment = Alignment.CenterVertically
@@ -322,13 +329,8 @@ fun LumenEmitterScreen(
                     }
                 }
 
-                Spacer(Modifier.height(12.dp))
-
-                Text(
-                    "Expected: " + expected.joinToString("-"),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                    Spacer(Modifier.height(12.dp))
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/indytrail/ui/MenuScreen.kt
+++ b/app/src/main/java/com/example/indytrail/ui/MenuScreen.kt
@@ -184,7 +184,7 @@ fun MenuScreen(
     onPathfinder: () -> Unit,
     onCodex: () -> Unit,
 ) {
-    // If you use immersive system bars you already have ImmersiveSystemBars() elsewhere.
+    ImmersiveSystemBars()
     Column(
         modifier = Modifier
             .fillMaxSize()

--- a/app/src/main/java/com/example/indytrail/ui/StationScreen.kt
+++ b/app/src/main/java/com/example/indytrail/ui/StationScreen.kt
@@ -16,6 +16,8 @@ fun StationScreen(
     onBack: () -> Unit,
     onSolved: (Station) -> Unit = {}
 ) {
+    ImmersiveSystemBars()
+
     var input by remember { mutableStateOf("") }
     var feedback by remember { mutableStateOf<String?>(null) }
 


### PR DESCRIPTION
## Summary
- Extend Lumen Emitter pad background, remove debug sequence text, and enable immersive mode.
- Add delayed, animated quest completion message with renamed Lumen Emitter button and disabled styling.
- Hide system UI bars across main screens for consistent immersive experience.

## Testing
- `./gradlew test` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_688ca71963b4832d8126788a003e1108